### PR TITLE
Weight matrix rowname change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+GeoLift v2.1.9 (Release date: 2021-11-17)
+=========================================
+
+Changes:
+
+* Row names from weight matrix were location names. Now they are another column within the matrix.
+
 GeoLift v2.1.8 (Release date: 2021-11-05)
 =========================================
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.1.8
+Version: 2.1.9
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -3422,7 +3422,7 @@ print.summary.GeoLift <- function(x, ...){
     )
     for (row in 1:nrow(x$weights)){
       if (abs(round(as.double(x$weights$weight[row]), 4)) >= 0.0001){
-        message(paste0(" * ", x$weights$location[row], ": ", x$weights$weight[row]))
+        message(paste0(" * ", x$weights$location[row], ": ", round(x$weights$weight[row], 4)))
       }
 
     }
@@ -3454,7 +3454,7 @@ print.summary.GeoLift <- function(x, ...){
     )
     for (row in 1:nrow(x$weights)){
       if (abs(round(as.double(x$weights$weight[row]), 4)) >= 0.0001){
-        message(paste0(" * ", x$weights$location[row], ": ", x$weights$weight[row]))
+        message(paste0(" * ", x$weights$location[row], ": ", round(x$weights$weight[row], 4)))
       }
       
     }

--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -3352,7 +3352,10 @@ summary.GeoLift <- function(object, ...){
     summ$Y_id <- object$Y_id
     summ$incremental <- object$incremental
     summ$bias <- mean(object$summary$bias_est)
-    summ$weights <- object$results$weights
+    summ$weights <- matrix(
+      c(dimnames(object$results$weights)[[1]], object$results$weights), 
+      nrow=nrow(object$results$weights), 
+      ncol=2)
     summ$CI <- object$ConfidenceIntervals
     summ$alpha <- object$summary$alpha
     summ$lower <- object$lower_bound
@@ -3417,9 +3420,9 @@ print.summary.GeoLift <- function(x, ...){
       "\n* Model Weights:"
     )
     )
-    for (row in 1:length(x$weights)){
-      if(round(x$weights[row],4) != 0){
-        message(paste0(" * ", dimnames(x$weights)[[1]][row], ": ",round(x$weights[row],4)))
+    for (row in 1:nrow(x$weights)){
+      if (round(as.double(x$weights[,2][row]), 4) != 0){
+        message(paste0(" * ", x$weights[,1][row], ": ", x$weights[, 2][row]))
       }
 
     }
@@ -3449,11 +3452,11 @@ print.summary.GeoLift <- function(x, ...){
       "\n* Model Weights:"
     )
     )
-    for (row in 1:length(x$weights)){
-      if(round(x$weights[row],4) != 0){
-        message(paste0(" * ", dimnames(x$weights)[[1]][row], ": ",round(x$weights[row],4)))
+    for (row in 1:nrow(x$weights)){
+      if (round(as.double(x$weights[,2][row]), 4) != 0){
+        message(paste0(" * ", x$weights[,1][row], ": ", x$weights[, 2][row]))
       }
-
+      
     }
   }
 

--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -3352,10 +3352,10 @@ summary.GeoLift <- function(object, ...){
     summ$Y_id <- object$Y_id
     summ$incremental <- object$incremental
     summ$bias <- mean(object$summary$bias_est)
-    summ$weights <- matrix(
-      c(dimnames(object$results$weights)[[1]], object$results$weights), 
-      nrow=nrow(object$results$weights), 
-      ncol=2)
+    summ$weights <- data.frame(
+      location = dimnames(object$results$weights)[[1]],
+      weight = unname(object$results$weights[,1])
+    )
     summ$CI <- object$ConfidenceIntervals
     summ$alpha <- object$summary$alpha
     summ$lower <- object$lower_bound
@@ -3421,8 +3421,8 @@ print.summary.GeoLift <- function(x, ...){
     )
     )
     for (row in 1:nrow(x$weights)){
-      if (round(as.double(x$weights[,2][row]), 4) != 0){
-        message(paste0(" * ", x$weights[,1][row], ": ", x$weights[, 2][row]))
+      if (abs(round(as.double(x$weights$weight[row]), 4)) >= 0.0001){
+        message(paste0(" * ", x$weights$location[row], ": ", x$weights$weight[row]))
       }
 
     }
@@ -3453,8 +3453,8 @@ print.summary.GeoLift <- function(x, ...){
     )
     )
     for (row in 1:nrow(x$weights)){
-      if (round(as.double(x$weights[,2][row]), 4) != 0){
-        message(paste0(" * ", x$weights[,1][row], ": ", x$weights[, 2][row]))
+      if (abs(round(as.double(x$weights$weight[row]), 4)) >= 0.0001){
+        message(paste0(" * ", x$weights$location[row], ": ", x$weights$weight[row]))
       }
       
     }


### PR DESCRIPTION
- When the weight matrix comes as an output of GeoLift, its row names are locations and its first column are the weights that the synth associates to them.
- Changing the row names to be another column in the matrix.
- Benefits:
1. When being passed as a json to lower funnel processes, it will come with locations and not just with weights (row names are not placed as an output of the json).
2. Makes it easier to pick it up, without having to call dimnames.