### PR TITLE
Change devtools to remotes and update repos to facebookincubator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+GeoLift v2.1.9 (Release date: 2021-12-03)
+=========================================
+
+Changes:
+
+* Updated documentation files to match new repository
+* Changed devtools for remotes as recommended install method
+
 GeoLift v2.1.8 (Release date: 2021-11-05)
 =========================================
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,17 @@
-GeoLift v2.1.9 (Release date: 2021-12-03)
+GeoLift v2.1.10 (Release date: 2021-12-03)
 =========================================
 
 Changes:
 
 * Updated documentation files to match new repository
 * Changed devtools for remotes as recommended install method
+
+GeoLift v2.1.9 (Release date: 2021-11-17)
+=========================================
+
+Changes:
+
+* Row names from weight matrix were location names. Now they are another column within the matrix.
 
 GeoLift v2.1.8 (Release date: 2021-11-05)
 =========================================

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.1.8
+Version: 2.1.9
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Imports:
     rlang
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Imports:
     rlang
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.1
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.1.9
+Version: 2.1.10
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ GeoLift requires or works with:
 - R version 4.0.0 or newer.
 
 ## Installing GeoLift
-To install the package, first make sure that `devtools` and `augsynth` are installed.
+To install the package, first make sure that `remotes` and `augsynth` are installed.
 
 ```
-install.packages("devtools", repos='http://cran.us.r-project.org')
-devtools::install_github("ebenmichael/augsynth")
+install.packages("remotes", repos='http://cran.us.r-project.org')
+remotes::install_github("ebenmichael/augsynth")
 ```
 
 Then, install the package from GitHub:
 
 ```
-devtools::install_github("facebookincubator/GeoLift")
+remotes::install_github("facebookincubator/GeoLift")
 ```
 
 ## Contacts

--- a/doc/GeoLift_Walkthrough.R
+++ b/doc/GeoLift_Walkthrough.R
@@ -13,10 +13,10 @@ knitr::opts_chunk$set(
 )
 
 ## ----install, results="hide", message=F, eval=F-------------------------------
-#  ## Install devtools if noy already installed
-#  install.packages("devtools", repos='http://cran.us.r-project.org')
+#  ## Install remotes if noy already installed
+#  install.packages("remotes", repos='http://cran.us.r-project.org')
 #  ## Install GeoLift from github
-#  devtools::install_github("ArturoEsquerra/GeoLift")
+#  remotes::install_github("facebookincubator/GeoLift")
 
 ## ----libraries, results="hide", warning=F, message=F--------------------------
 library(augsynth)

--- a/doc/GeoLift_Walkthrough.Rmd
+++ b/doc/GeoLift_Walkthrough.Rmd
@@ -28,7 +28,7 @@ You can install `GeoLift` from GitHub using the `devtools` package.
 ## Install devtools if noy already installed
 install.packages("devtools", repos='http://cran.us.r-project.org')
 ## Install GeoLift from github
-devtools::install_github("ArturoEsquerra/GeoLift")
+devtools::install_github("facebookincubator/GeoLift")
 ```
 
 ```{r libraries, results="hide", warning=F, message=F}

--- a/doc/GeoLift_Walkthrough.Rmd
+++ b/doc/GeoLift_Walkthrough.Rmd
@@ -22,13 +22,13 @@ knitr::opts_chunk$set(
 
 ## Installation
 
-You can install `GeoLift` from GitHub using the `devtools` package.
+You can install `GeoLift` from GitHub using the `remotes` package.
 
 ```{r install, results="hide", message=F, eval=F}
-## Install devtools if noy already installed
-install.packages("devtools", repos='http://cran.us.r-project.org')
+## Install remotes if noy already installed
+install.packages("remotes", repos='http://cran.us.r-project.org')
 ## Install GeoLift from github
-devtools::install_github("facebookincubator/GeoLift")
+remotes::install_github("facebookincubator/GeoLift")
 ```
 
 ```{r libraries, results="hide", warning=F, message=F}

--- a/doc/GeoLift_Walkthrough.html
+++ b/doc/GeoLift_Walkthrough.html
@@ -340,11 +340,11 @@ code > span.er { color: #a61717; background-color: #e3d2d2; }
 <h1><code>GeoLift</code>: And end-to-end solution to Measure Lift at a Geo Level</h1>
 <div id="installation" class="section level2">
 <h2>Installation</h2>
-<p>You can install <code>GeoLift</code> from GitHub using the <code>devtools</code> package.</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1"></a><span class="co">## Install devtools if noy already installed</span></span>
-<span id="cb1-2"><a href="#cb1-2"></a><span class="kw">install.packages</span>(<span class="st">&quot;devtools&quot;</span>, <span class="dt">repos=</span><span class="st">&#39;http://cran.us.r-project.org&#39;</span>)</span>
+<p>You can install <code>GeoLift</code> from GitHub using the <code>remotes</code> package.</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1"></a><span class="co">## Install remotes if noy already installed</span></span>
+<span id="cb1-2"><a href="#cb1-2"></a><span class="kw">install.packages</span>(<span class="st">&quot;remotes&quot;</span>, <span class="dt">repos=</span><span class="st">&#39;http://cran.us.r-project.org&#39;</span>)</span>
 <span id="cb1-3"><a href="#cb1-3"></a><span class="co">## Install GeoLift from github</span></span>
-<span id="cb1-4"><a href="#cb1-4"></a>devtools<span class="op">::</span><span class="kw">install_github</span>(<span class="st">&quot;ArturoEsquerra/GeoLift&quot;</span>)</span></code></pre></div>
+<span id="cb1-4"><a href="#cb1-4"></a>remotes<span class="op">::</span><span class="kw">install_github</span>(<span class="st">&quot;ArturoEsquerra/GeoLift&quot;</span>)</span></code></pre></div>
 <div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1"></a><span class="kw">library</span>(augsynth)</span>
 <span id="cb2-2"><a href="#cb2-2"></a><span class="kw">library</span>(gsynth)</span>
 <span id="cb2-3"><a href="#cb2-3"></a><span class="kw">library</span>(GeoLift)</span>

--- a/doc/GeoLift_Walkthrough.html
+++ b/doc/GeoLift_Walkthrough.html
@@ -344,7 +344,7 @@ code > span.er { color: #a61717; background-color: #e3d2d2; }
 <div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1"></a><span class="co">## Install remotes if noy already installed</span></span>
 <span id="cb1-2"><a href="#cb1-2"></a><span class="kw">install.packages</span>(<span class="st">&quot;remotes&quot;</span>, <span class="dt">repos=</span><span class="st">&#39;http://cran.us.r-project.org&#39;</span>)</span>
 <span id="cb1-3"><a href="#cb1-3"></a><span class="co">## Install GeoLift from github</span></span>
-<span id="cb1-4"><a href="#cb1-4"></a>remotes<span class="op">::</span><span class="kw">install_github</span>(<span class="st">&quot;ArturoEsquerra/GeoLift&quot;</span>)</span></code></pre></div>
+<span id="cb1-4"><a href="#cb1-4"></a>remotes<span class="op">::</span><span class="kw">install_github</span>(<span class="st">&quot;facebookincubator/GeoLift&quot;</span>)</span></code></pre></div>
 <div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1"></a><span class="kw">library</span>(augsynth)</span>
 <span id="cb2-2"><a href="#cb2-2"></a><span class="kw">library</span>(gsynth)</span>
 <span id="cb2-3"><a href="#cb2-3"></a><span class="kw">library</span>(GeoLift)</span>

--- a/vignettes/GeoLift_Walkthrough.Rmd
+++ b/vignettes/GeoLift_Walkthrough.Rmd
@@ -22,14 +22,14 @@ knitr::opts_chunk$set(
 
 ## Installation
 
-You can install `GeoLift` from GitHub using the `devtools` package.
+You can install `GeoLift` from GitHub using the `remotes`` package.
 
 ```{r install, results="hide", message=F, eval=F}
-## Install devtools if noy already installed
-install.packages("devtools", repos='http://cran.us.r-project.org')
+## Install remotes if noy already installed
+install.packages("remotes", repos='http://cran.us.r-project.org')
 ## Install augsynth & GeoLift from GitHub
-devtools::install_github("ebenmichael/augsynth")
-devtools::install_github("facebookincubator/GeoLift")
+remotes::install_github("ebenmichael/augsynth")
+remotes::install_github("facebookincubator/GeoLift")
 ```
 
 ```{r libraries, results="hide", warning=F, message=F}

--- a/vignettes/GeoLift_Walkthrough.md
+++ b/vignettes/GeoLift_Walkthrough.md
@@ -5,14 +5,14 @@ GeoLift\_Walkthrough
 
 ## Installation
 
-You can install `GeoLift` from GitHub using the `devtools` package.
+You can install `GeoLift` from GitHub using the `remotes` package.
 
 ``` r
-## Install devtools if noy already installed
-install.packages("devtools", repos='http://cran.us.r-project.org')
+## Install remotes if noy already installed
+install.packages("remotes", repos='http://cran.us.r-project.org')
 ## Install augsynth & GeoLift from GitHub
-devtools::install_github("ebenmichael/augsynth")
-devtools::install_github("ArturoEsquerra/GeoLift")
+remotes::install_github("ebenmichael/augsynth")
+remotes::install_github("facebookincubator/GeoLift")
 ```
 
 ``` r

--- a/website/docs/GettingStarted/InstallingR.md
+++ b/website/docs/GettingStarted/InstallingR.md
@@ -16,22 +16,22 @@ If you have questions about R like how to download and install the software, or 
 
 ## 2. Installing the GeoLift Package
 
-Since GeoLift is currently only available on GitHub, the `devtools` package is a pre-requisite to install it. If you haven't installed this package yet, first run:
+Since GeoLift is currently only available on GitHub, the `remotes` package is a pre-requisite to install it. If you haven't installed this package yet, first run:
 
 ```
-install.packages("devtools", repos='http://cran.us.r-project.org')
+install.packages("remotes", repos='http://cran.us.r-project.org')
 ```
 
 Moreover, GeoLift relies on an implementation of Augmented Synthetic Control Models which can be found in the `augsynth` package, which is also hosted on GitHub. It is important to install it before moving on to GeoLift.
 
 ```
-devtools::install_github("ebenmichael/augsynth")
+remotes::install_github("ebenmichael/augsynth")
 ```
 
 Finally, we can install the `GeoLift` package with the following command:
 
 ```
-devtools::install_github("facebookincubator/GeoLift")
+remotes::install_github("facebookincubator/GeoLift")
 ```
 
 ---


### PR DESCRIPTION
- Suggested `remotes` instead of `devtools` because it's lighter and only needed to run `install_github`
- Updated facebookincubator everywhere