### PR TITLE
[FIX] No suitable treatment market combinations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+GeoLift v2.3.6 (Release date: 2022-03-21)
+=========================================
+
+Changes:
+
+* Added stop when no combinations that fit criteria are obtained in GeoLiftMarketSelection.
+* Skipped iterations when power dataframe returns zero rows.
+
 GeoLift v2.3.5 (Release date: 2022-03-14)
 =========================================
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.3.5
+Version: 2.3.6
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/R/pre_test_power.R
+++ b/R/pre_test_power.R
@@ -1858,28 +1858,31 @@ GeoLiftMarketSelection <- function(data,
   for (locs in unique(results$location)) {
     for (ts in treatment_periods) {
       resultsFindAux <- results %>% dplyr::filter(location == locs & duration == ts & power > 0.8)
-      negative_mde <- max(
-        ifelse(resultsFindAux$EffectSize < 0,
-          resultsFindAux$EffectSize,
-          min(effect_size) - 1
+      
+      if (nrow(resultsFindAux) != 0){
+        negative_mde <- max(
+          ifelse(resultsFindAux$EffectSize < 0,
+            resultsFindAux$EffectSize,
+            min(effect_size) - 1
+          )
         )
-      )
-      positive_mde <- min(
-        ifelse(resultsFindAux$EffectSize > 0,
-          resultsFindAux$EffectSize,
-          max(effect_size) + 1
+        positive_mde <- min(
+          ifelse(resultsFindAux$EffectSize > 0,
+            resultsFindAux$EffectSize,
+            max(effect_size) + 1
+          )
         )
-      )
-      MDEAux <- ifelse(
-        positive_mde > abs(negative_mde) & negative_mde != 0,
-        negative_mde,
-        positive_mde
-      )
-
-      resultsFindAux <- resultsFindAux %>% dplyr::filter(EffectSize == MDEAux)
-
-      if (MDEAux != 0) { # Drop tests significant with ES = 0
-        resultsM <- resultsM %>% dplyr::bind_rows(resultsFindAux)
+        MDEAux <- ifelse(
+          positive_mde > abs(negative_mde) & negative_mde != 0,
+          negative_mde,
+          positive_mde
+        )
+  
+        resultsFindAux <- resultsFindAux %>% dplyr::filter(EffectSize == MDEAux)
+  
+        if (MDEAux != 0) { # Drop tests significant with ES = 0
+          resultsM <- resultsM %>% dplyr::bind_rows(resultsFindAux)
+        }
       }
     }
   }

--- a/R/pre_test_power.R
+++ b/R/pre_test_power.R
@@ -1886,6 +1886,9 @@ GeoLiftMarketSelection <- function(data,
       }
     }
   }
+  if (is.null(resultsM)){
+    stop('No good setups were found.  Please change hyperparameters.')
+  }
 
   # Step 5 - Add Percent of Y in test markets
   # Step 5.1 - Create the overall prop

--- a/R/pre_test_power.R
+++ b/R/pre_test_power.R
@@ -1465,7 +1465,7 @@ GeoLiftPower <- function(data,
                    \nIt's recommended to have at least 4x pre-treatment periods for each treatment period.\n"))
   }
 
-  if (lookback_window <= 0){
+  if (lookback_window <= 0) {
     lookback_window <- 1
   }
 
@@ -1858,8 +1858,8 @@ GeoLiftMarketSelection <- function(data,
   for (locs in unique(results$location)) {
     for (ts in treatment_periods) {
       resultsFindAux <- results %>% dplyr::filter(location == locs & duration == ts & power > 0.8)
-      
-      if (nrow(resultsFindAux) != 0){
+
+      if (nrow(resultsFindAux) != 0) {
         negative_mde <- max(
           ifelse(resultsFindAux$EffectSize < 0,
             resultsFindAux$EffectSize,
@@ -1877,17 +1877,17 @@ GeoLiftMarketSelection <- function(data,
           negative_mde,
           positive_mde
         )
-  
+
         resultsFindAux <- resultsFindAux %>% dplyr::filter(EffectSize == MDEAux)
-  
+
         if (MDEAux != 0) { # Drop tests significant with ES = 0
           resultsM <- resultsM %>% dplyr::bind_rows(resultsFindAux)
         }
       }
     }
   }
-  if (is.null(resultsM)){
-    stop('No good setups were found.  Please change hyperparameters.')
+  if (is.null(resultsM)) {
+    stop('\nNo markets meet the criteria you provided. Consider modifying the input hyperparameters"')
   }
 
   # Step 5 - Add Percent of Y in test markets

--- a/R/pre_test_power.R
+++ b/R/pre_test_power.R
@@ -1887,7 +1887,7 @@ GeoLiftMarketSelection <- function(data,
     }
   }
   if (is.null(resultsM)) {
-    stop('\nNo markets meet the criteria you provided. Consider modifying the input hyperparameters"')
+    stop('\nNo markets meet the criteria you provided. Consider modifying the input hyperparameters.')
   }
 
   # Step 5 - Add Percent of Y in test markets


### PR DESCRIPTION
- Added stop criteria when no suitable combination of markets for treatment is obtained.
- Skip combination of market iteration when there are no effect sizes that satisfy power > 0.8

Tackles issue https://github.com/facebookincubator/GeoLift/issues/47