### PR TITLE
[pre_test_power] Refactor run_simulations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+GeoLift v2.5.3 (Release date: 2022-11-07)
+=========================================
+
+Changes:
+* Refactored for loops in run_simulations to adapt to foreach structure.
+* Cut down time in GeoLiftPower by 3.5x.
+
 GeoLift v2.5.21 (Release date: 2022-09-16)
 =========================================
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-GeoLift v2.5.3 (Release date: 2022-11-07)
+GeoLift v2.6 (Release date: 2022-11-08)
 =========================================
 
 Changes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.5.3
+Version: 2.6
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.5.21
+Version: 2.5.3
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/R/imports.R
+++ b/R/imports.R
@@ -95,6 +95,7 @@ utils::globalVariables(
     "time",
     "Time",
     "Total_Y",
+    "treatment_duration",
     "treatment_group_size",
     "treatment_location",
     "treatment_start",

--- a/man/run_simulations.Rd
+++ b/man/run_simulations.Rd
@@ -12,7 +12,7 @@ run_simulations(
   side_of_test = "two_sided",
   lookback_window = 1,
   parallel = TRUE,
-  pb = NULL,
+  ProgressBar = FALSE,
   cpic = 0,
   X = c(),
   normalize = FALSE,
@@ -50,7 +50,8 @@ will only execute the most recent test based on the data.}
 \item{parallel}{A logic flag indicating whether to use parallel computing to
 speed up calculations. Set to TRUE by default.}
 
-\item{pb}{ProgressBar object. NULL by default.}
+\item{ProgressBar}{A logic flag indicating whether to display a progress bar
+to track progress. Set to FALSE by default.}
 
 \item{cpic}{Number indicating the Cost Per Incremental Conversion.}
 


### PR DESCRIPTION
- This PR leaves the run_simulations function much cleaner, leveraging the foreach structure we already had.
- It also makes the GeoLiftPower function run much faster because we are parallelizing everything, not just one parameter (in a standard Walkthrough example, goes from 42 secs to 12 secs).

Unit test:
```
library(GeoLift)
data(GeoLift_PreTest)
geo_data <- GeoDataRead(data = GeoLift_PreTest,
                           date_id = "date",
                           location_id = "location",
                           Y_id = "Y",
                           X = c(), #empty list as we have no covariates
                           format = "yyyy-mm-dd",
                           summary = TRUE)


MarketSelections <- GeoLiftMarketSelection(data = geo_data,
                                           treatment_periods = c(10,15),
                                           N = c(2,3,4,5),
                                           Y_id = "Y",
                                           location_id = "location",
                                           time_id = "time",
                                           effect_size = seq(0, 0.2, 0.05),
                                           lookback_window = 1, 
                                           include_markets = c("chicago"),
                                           exclude_markets = c("honolulu"),
                                           cpic = 7.50,
                                           budget = 100000,
                                           alpha = 0.1,
                                           Correlations = TRUE,
                                           fixed_effects = TRUE,
                                           ProgressBar = FALSE,
                                           side_of_test = "one_sided",
                                           parallel=TRUE)

market_id = 2
market_row <- MarketSelections$BestMarkets %>% dplyr::filter(ID == market_id)
treatment_locations <- stringr::str_split(market_row$location, ", ")[[1]]
treatment_duration <- market_row$duration
lookback_window <- 7

start <- Sys.time() 
power_data <- GeoLiftPower(
  data = geo_data,
  locations = treatment_locations,
  effect_size = seq(-0.25, 0.25, 0.01),
  lookback_window = lookback_window,
  treatment_periods = treatment_duration,
  cpic = 7.5,
  side_of_test = "one_sided",
  ProgressBar = FALSE,
  parallel=TRUE
)
end <- Sys.time() 
end-start
```

