### PR TITLE
Check that treatment_start_time and treatment_end_time are integers before proceeding with GeoLiftMultiCell.

### DIFF
--- a/R/MultiCell.R
+++ b/R/MultiCell.R
@@ -802,12 +802,12 @@ GeoLiftMultiCell <- function(Y_id = "Y",
   }
 
   # Check treatment_start_time                                                  
-  if(treatment_start_time==as.integer(treatment_start_time)){                   
+  if(!(treatment_start_time==as.integer(treatment_start_time))){
     stop("\nPlease specify a valid integer treatment_start_time.")              
   }                                                                             
 
   # Check treatment_end_time                                                    
-  if(treatment_end_time==as.integer(treatment_end_time)){                                                                                                      
+  if(!(treatment_end_time==as.integer(treatment_end_time))){
     stop("\nPlease specify a valid integer treatment_end_time.")                
   }
 


### PR DESCRIPTION
I know this change is trivial, but I just lost two hours because I used `treatment_start_time = difftime("2022-08-14","2020-10-26")` as input for `GeoLiftMultiCell` and it only complained about this being incorrect after it had completed the model selection step. I hope this addition will save someone else a few hours of waiting.