### PR TITLE
Add Stratified Randomization to MultiCellMarketSelection

### DIFF
--- a/R/MultiCell.R
+++ b/R/MultiCell.R
@@ -147,7 +147,7 @@ MultiCellMarketSelection <- function(data,
   }
 
   # Check Sampling Method
-  if(!(tolower(sampling_method) %in% c("systematic"))){
+  if(!(tolower(sampling_method) %in% c("systematic", "blockrand"))){
     stop("\nEnter a valid sampling_method (check the function documentation for more details).")
   }
 
@@ -200,6 +200,14 @@ MultiCellMarketSelection <- function(data,
 
     for (i in 1:length(r)){
       rank_by_loc$cell[seq(r[i], locs_N, k)] <- i
+    }
+  }
+  # Stratified or 'Block' Randomization
+  else if(tolower(sampling_method) == "blockrand"){
+    rank_by_loc$strata <- ceiling((1:locs_N/k))
+    
+    for (i in 1:max(rank_by_loc$strata)){
+      suppressWarnings(rank_by_loc$cell[rank_by_loc$strata==i] <- sample(1:k,k))
     }
   }
 

--- a/R/MultiCell.R
+++ b/R/MultiCell.R
@@ -147,7 +147,7 @@ MultiCellMarketSelection <- function(data,
   }
 
   # Check Sampling Method
-  if(!(tolower(sampling_method) %in% c("systematic", "blockrand"))){
+  if(!(tolower(sampling_method) %in% c("systematic", "stratified"))){
     stop("\nEnter a valid sampling_method (check the function documentation for more details).")
   }
 
@@ -203,8 +203,8 @@ MultiCellMarketSelection <- function(data,
     }
   }
   # Stratified or 'Block' Randomization
-  else if(tolower(sampling_method) == "blockrand"){
-    rank_by_loc$strata <- ceiling((1:locs_N/k))
+  else if(tolower(sampling_method) == "stratified"){
+    rank_by_loc$strata <- ceiling(1:locs_N/k)
     
     for (i in 1:max(rank_by_loc$strata)){
       suppressWarnings(rank_by_loc$cell[rank_by_loc$strata==i] <- sample(1:k,k))


### PR DESCRIPTION
Added 'stratified' as an alternative sampling method. This stratifies the locations in rank_by_loc and then randomizes the cell assignment within each strata.

The current 'systematic' method only randomizes sample(1:k,k) once, and then repeats that sequence down the rank_by_loc. This produces identical groupings of markets in data_aux for MultiCellMarketSelection each time we run it, even though the cell number labels may differ. This is a potentially significant source of bias when running MultiCellMarketSelection for subsequent experiments with the same number of cells. By randomizing at each strata, we can ensure the market groupings in data_aux will be truly different by setting a different seed.