### PR TITLE
fix covariates in GeoDataRead and update of version to 2.7.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoLift
 Title: Synthetic Control Method to Calculate Lift at a Geo Level
-Version: 2.7.3
+Version: 2.7.4
 Authors@R: c(
     person(given = "Arturo",
            family = "Esquerra",

--- a/R/pre_processing_data.R
+++ b/R/pre_processing_data.R
@@ -201,10 +201,22 @@ GeoDataRead <- function(data,
     data <- data_raw %>%
       dplyr::group_by(location, time) %>%
       dplyr::summarize(Y = sum(Y))
+    for (var in X) {
+      data_aux <- data_raw %>%
+        dplyr::group_by(location, time) %>%
+        dplyr::summarize(!!var := sum(!!sym(var)))
+      data <- data %>% dplyr::left_join(data_aux, by = c("location", "time"))
+    }
   } else {
     data <- data_raw %>%
       dplyr::group_by(location, time, date_unix) %>%
       dplyr::summarize(Y = sum(Y))
+    for (var in X) {
+      data_aux <- data_raw %>%
+        dplyr::group_by(location, time, date_unix) %>%
+        dplyr::summarize(!!var := sum(!!sym(var)))
+      data <- data %>% dplyr::left_join(data_aux, by = c("location", "time", "date_unix"))
+    }
   }
 
   # Print summary of Data Reading


### PR DESCRIPTION
Fix that corrects GeoDataRead to take Covariates into account again and update of the version from 2.7.3 to 2.7.4. Based on the issue: https://github.com/facebookincubator/GeoLift/issues/169

Suggestion for testing:

```
head(GeoLift_PreTest)

GeoLift_PreTest$clicks <- GeoLift_PreTest$Y*(100 + rnorm(n=10, sd=0.05)) 


GeoTestData_PreTest <- GeoDataRead(data = GeoLift_PreTest,
                                   date_id = "date",
                                   location_id = "location",
                                   Y_id = "Y",
                                   X = c("clicks"),
                                   format = "yyyy-mm-dd",
                                   summary = TRUE)

head(GeoTestData_PreTest)
```