### PR TITLE
Streamline installation instructions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,5 +61,7 @@ RoxygenNote: 7.2.3
 Suggests:
     CommutingZones,
     rmarkdown
+Remotes:
+    ebenmichael/augsynth
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ GeoLift requires or works with:
 - R version 4.0.0 or newer.
 
 ## Installing GeoLift
-To install the package, first make sure that `remotes` and
-`augsynth` are installed.
+To install the package, first make sure that `remotes` is installed.
 
 ```
 install.packages("remotes", repos='http://cran.us.r-project.org')
-remotes::install_github("ebenmichael/augsynth")
 ```
 
 Then, install the package from GitHub:

--- a/vignettes/GeoLift_Walkthrough.Rmd
+++ b/vignettes/GeoLift_Walkthrough.Rmd
@@ -44,8 +44,7 @@ You can install `GeoLift` from our [GitHub repository](https://github.com/facebo
 ```{r install, results="hide", message=F, eval=F}
 ## Install remotes if noy already installed
 install.packages("remotes", repos = "http://cran.us.r-project.org")
-## Install augsynth & GeoLift from GitHub
-remotes::install_github("ebenmichael/augsynth")
+## Install GeoLift from GitHub
 remotes::install_github("facebookincubator/GeoLift")
 ```
 

--- a/website/docs/GettingStarted/InstallingR.md
+++ b/website/docs/GettingStarted/InstallingR.md
@@ -22,13 +22,7 @@ Since GeoLift is currently only available on GitHub, the `remotes` package is a 
 install.packages("remotes", repos='http://cran.us.r-project.org')
 ```
 
-To install the package, first make sure that remotes and `augsynth` are installed.
-
-```
-remotes::install_github("ebenmichael/augsynth")
-```
-
-Finally, we can install the `GeoLift` package with the following command:
+Then we can install the `GeoLift` package with the following command:
 
 ```
 remotes::install_github("facebookincubator/GeoLift")


### PR DESCRIPTION
This PR makes a small change to the DESCRIPTION file so that augsynth will be installed automatically, with no need for a separate call to `install_github()`. With `Remotes: ebenmichael/augsynth` in the DESCRIPTION file, remotes will know to install augsynth from GitHub when installing GeoLift. Reproducible example below showing that it works:
``` r
remove.packages("augsynth")
#> Removing package from '/Users/kara/Library/R/arm64/4.4/library'
#> (as 'lib' is unspecified)
```

``` r
"augsynth" %in% installed.packages()
#> [1] FALSE
```

``` r
remotes::install_github("karawoo/GeoLift@streamline-installation", force = TRUE, quiet = TRUE)
c("augsynth", "GeoLift") %in% installed.packages()
#> [1] TRUE TRUE
```

<sup>Created on 2024-05-28 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Hope you'll pardon my opening a PR without filing an issue first; if there's a specific reason for installing augsynth separately then please disregard this PR.