### PR TITLE
Make model = "best" consistent across entry points

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,6 +60,7 @@ LazyData: true
 RoxygenNote: 7.2.3
 Suggests:
     CommutingZones,
-    rmarkdown
+    rmarkdown,
+    testthat
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/R/MultiCell.R
+++ b/R/MultiCell.R
@@ -752,7 +752,7 @@ print.MultiCellWinner <- function(x, ...) {
 #'          \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 #'                          to improve fit for larger panels (more than 40 locations and 100
 #'                          time-stamps. }
-#'          \item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+#'          \item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 #'          }
 #' @param fixed_effects A logic flag indicating whether to include unit fixed
 #' effects in the model. Set to TRUE by default.

--- a/R/auxiliary.R
+++ b/R/auxiliary.R
@@ -42,6 +42,102 @@ fn_treatment <- function(df,
 }
 
 
+#' Resolve model = "best" into a concrete outcome model.
+#'
+#' @description
+#' Internal helper used by \code{GeoLift} and \code{GetWeights} when
+#' \code{model = "best"}. Fits the candidate prognostic functions
+#' ("none", "ridge", "GSYN") and returns the name of the one with the
+#' lowest Scaled L2 Imbalance; ties go to the simpler model (none, then
+#' ridge, then GSYN). A candidate that fails to fit, or whose imbalance
+#' is not a single finite number, is excluded from the comparison with a
+#' message; if every candidate fails, an error is raised.
+#'
+#' @param data A data.frame containing the historical conversions by
+#' geographic unit.
+#' @param treatment_locations Vector of treatment locations.
+#' @param treatment_start_time Time index of the start of the treatment.
+#' @param treatment_end_time Time index of the end of the treatment.
+#' @param Y_id Name of the outcome variable (String).
+#' @param time_id Name of the time variable (String).
+#' @param location_id Name of the location variable (String).
+#' @param X List of names of covariates.
+#' @param fixed_effects A logic flag indicating whether to include unit
+#' fixed effects in the model. Set to TRUE by default.
+#'
+#' @return
+#' String with the name of the selected model ("none", "ridge" or "GSYN").
+#'
+#' @noRd
+ResolveBestModel <- function(data,
+                             treatment_locations,
+                             treatment_start_time,
+                             treatment_end_time,
+                             Y_id = "Y",
+                             time_id = "time",
+                             location_id = "location",
+                             X = c(),
+                             fixed_effects = TRUE) {
+  ascm_imbalances <- list()
+  for (progfunc in c("none", "ridge", "GSYN")) {
+    if (length(treatment_locations) == 1 & progfunc == "GSYN") {
+      message("model = 'best': skipping the GSYN candidate (single treatment location).")
+      ascm_imbalances[[progfunc]] <- Inf
+    } else {
+      ascm_imbalances[[progfunc]] <- tryCatch(
+        expr = {
+          l2 <- ASCMExecution(
+            data = data,
+            treatment_locations = treatment_locations,
+            treatment_start_time = treatment_start_time,
+            treatment_end_time = treatment_end_time,
+            Y_id = Y_id,
+            time_id = time_id,
+            location_id = location_id,
+            X = X,
+            model = progfunc,
+            fixed_effects = fixed_effects
+          )$augsynth_model$scaled_l2_imbalance
+          if (!(is.numeric(l2) && length(l2) == 1 && is.finite(l2))) {
+            stop("scaled_l2_imbalance is not a single finite number")
+          }
+          round(l2, 3)
+        },
+        error = function(e) {
+          message(sprintf(
+            "model = 'best': candidate '%s' failed and was excluded from the comparison (%s)",
+            progfunc, conditionMessage(e)
+          ))
+          Inf
+        }
+      )
+    }
+  }
+
+  scores <- unlist(ascm_imbalances[c("none", "ridge", "GSYN")])
+
+  if (all(is.infinite(scores))) {
+    stop(
+      "model = 'best': every candidate model failed to fit. ",
+      "See the messages above for the underlying errors."
+    )
+  }
+
+  # Lowest Scaled L2 Imbalance among the candidates that fitted, as
+  # documented; ties go to the simpler model (none, then ridge, then GSYN).
+  best <- names(scores)[which.min(scores)]
+
+  if (best == "GSYN") {
+    message("Selected GSYN as best model.")
+  } else if (best == "ridge") {
+    message("Selected Ridge as best model.")
+  } else {
+    message("Selected model without prognostic function as best model.")
+  }
+  return(best)
+}
+
+
 
 #' Build cluster to parallelize operations across nodes in machine.
 #'
@@ -299,7 +395,7 @@ CorrelationCoefficient <- function(data, locs = c()) {
 #'          \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 #'                          to improve fit for larger panels (more than 40 locations and 100
 #'                          time-stamps. }
-#'          \item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+#'          \item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 #'          }
 #' @param fixed_effects A logic flag indicating whether to include unit fixed
 #' effects in the model. Set to TRUE by default.
@@ -337,6 +433,18 @@ GetWeights <- function(Y_id = "Y",
   } else {
     treatment_start_time <- pretreatment_end_time + 1
     treatment_end_time <- max(data$time)
+  }
+
+  # Optimizing model based on Scaled L2 Score
+  if (model == "best") {
+    model <- ResolveBestModel(
+      data = data,
+      treatment_locations = locations,
+      treatment_start_time = treatment_start_time,
+      treatment_end_time = treatment_end_time,
+      X = X,
+      fixed_effects = fixed_effects
+    )
   }
 
   data_aux <- fn_treatment(data,

--- a/R/post_test_analysis.R
+++ b/R/post_test_analysis.R
@@ -33,7 +33,6 @@
 #'          \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 #'                          to improve fit for larger panels (more than 40 locations and 100
 #'                          time-stamps. }
-#'          \item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
 #'          }
 #' @param fixed_effects A logic flag indicating whether to include unit fixed
 #' effects in the model. Set to TRUE by default.
@@ -137,7 +136,7 @@ ASCMExecution <- function(
 #'          \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 #'                          to improve fit for larger panels (more than 40 locations and 100
 #'                          time-stamps. }
-#'          \item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+#'          \item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 #'          }
 #' @param fixed_effects A logic flag indicating whether to include unit fixed
 #' effects in the model. Set to TRUE by default.
@@ -205,44 +204,17 @@ GeoLift <- function(Y_id = "Y",
                     ns = 1000) {
   # Optimizing model based on Scaled L2 Score
   if (model == "best") {
-    ascm_imbalances <- list()
-    for (progfunc in c("none", "ridge", "GSYN")) {
-      if (length(locations) == 1 & progfunc == "GSYN") {
-        ascm_imbalances[[progfunc]] <- list("scaled_l2_imbalance" = 1)
-      } else {
-        ascm <- tryCatch(
-          expr = {
-            ASCMExecution(
-              data = data,
-              treatment_locations = locations,
-              treatment_start_time = treatment_start_time,
-              treatment_end_time = treatment_end_time,
-              Y_id = Y_id,
-              time_id = time_id,
-              location_id = location_id,
-              X = X,
-              model = progfunc,
-              fixed_effects = fixed_effects
-            )$augsynth_model
-          },
-          error = function(e) {
-            list("scaled_l2_imbalance" = 1)
-          }
-        )
-        ascm_imbalances[[eval(progfunc)]] <- round(ascm$scaled_l2_imbalance, 3)
-      }
-    }
-
-    if (ascm_imbalances$none > ascm_imbalances$GSYN & ascm_imbalances$ridge > ascm_imbalances$GSYN) {
-      message("Selected GSYN as best model.")
-      model <- "GSYN"
-    } else if (ascm_imbalances$none > ascm_imbalances$ridge & ascm_imbalances$GSYN > ascm_imbalances$ridge) {
-      message("Selected Ridge as best model.")
-      model <- "ridge"
-    } else {
-      message("Selected model without prognostic function as best model.")
-      model <- "none"
-    }
+    model <- ResolveBestModel(
+      data = data,
+      treatment_locations = locations,
+      treatment_start_time = treatment_start_time,
+      treatment_end_time = treatment_end_time,
+      Y_id = Y_id,
+      time_id = time_id,
+      location_id = location_id,
+      X = X,
+      fixed_effects = fixed_effects
+    )
   }
   augsynth_result_list <- ASCMExecution(
     data = data,

--- a/R/pre_test_power.R
+++ b/R/pre_test_power.R
@@ -642,6 +642,13 @@ GeoLiftPowerFinder <- function(data,
                                parallel = TRUE,
                                parallel_setup = "sequential",
                                side_of_test = "two_sided") {
+  if (model == "best") {
+    stop(
+      "model = 'best' is only supported in GeoLift() and GetWeights(), ",
+      "which fit a single design. Simulation-based functions fit one ",
+      "outcome model at a time: use model = 'none', 'ridge' or 'GSYN'."
+    )
+  }
   if (parallel == TRUE) {
     cl <- build_cluster(
       parallel_setup = parallel_setup
@@ -948,6 +955,13 @@ GeoLiftPower.search <- function(data,
                                 run_stochastic_process = FALSE,
                                 parallel = TRUE,
                                 parallel_setup = "sequential") {
+  if (model == "best") {
+    stop(
+      "model = 'best' is only supported in GeoLift() and GetWeights(), ",
+      "which fit a single design. Simulation-based functions fit one ",
+      "outcome model at a time: use model = 'none', 'ridge' or 'GSYN'."
+    )
+  }
   if (parallel == TRUE) {
     cl <- build_cluster(
       parallel_setup = parallel_setup
@@ -1181,6 +1195,13 @@ NumberLocations <- function(data,
                             ProgressBar = FALSE,
                             parallel = TRUE,
                             parallel_setup = "sequential") {
+  if (model == "best") {
+    stop(
+      "model = 'best' is only supported in GeoLift() and GetWeights(), ",
+      "which fit a single design. Simulation-based functions fit one ",
+      "outcome model at a time: use model = 'none', 'ridge' or 'GSYN'."
+    )
+  }
   if (parallel == TRUE) {
     cl <- build_cluster(
       parallel_setup = parallel_setup
@@ -1448,6 +1469,13 @@ GeoLiftPower <- function(data,
                          side_of_test = "two_sided",
                          conformal_type = "iid",
                          ns = 1000) {
+  if (model == "best") {
+    stop(
+      "model = 'best' is only supported in GeoLift() and GetWeights(), ",
+      "which fit a single design. Simulation-based functions fit one ",
+      "outcome model at a time: use model = 'none', 'ridge' or 'GSYN'."
+    )
+  }
   if (parallel == TRUE) {
     cl <- build_cluster(
       parallel_setup = parallel_setup
@@ -1634,6 +1662,13 @@ GeoLiftMarketSelection <- function(data,
                                    side_of_test = "two_sided",
                                    conformal_type = "iid",
                                    ns = 1000) {
+  if (model == "best") {
+    stop(
+      "model = 'best' is only supported in GeoLift() and GetWeights(), ",
+      "which fit a single design. Simulation-based functions fit one ",
+      "outcome model at a time: use model = 'none', 'ridge' or 'GSYN'."
+    )
+  }
   if (parallel == TRUE) {
     cl <- build_cluster(
       parallel_setup = parallel_setup

--- a/man/ASCMExecution.Rd
+++ b/man/ASCMExecution.Rd
@@ -47,7 +47,6 @@ for smaller panels (less than 40 locations and 100 time-stamps.))}
 \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 to improve fit for larger panels (more than 40 locations and 100
 time-stamps. }
-\item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
 }}
 
 \item{fixed_effects}{A logic flag indicating whether to include unit fixed

--- a/man/GeoLift.Rd
+++ b/man/GeoLift.Rd
@@ -81,7 +81,7 @@ for smaller panels (less than 40 locations and 100 time-stamps.))}
 \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 to improve fit for larger panels (more than 40 locations and 100
 time-stamps. }
-\item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+\item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 }}
 
 \item{fixed_effects}{A logic flag indicating whether to include unit fixed

--- a/man/GeoLiftMultiCell.Rd
+++ b/man/GeoLiftMultiCell.Rd
@@ -78,7 +78,7 @@ for smaller panels (less than 40 locations and 100 time-stamps.))}
 \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 to improve fit for larger panels (more than 40 locations and 100
 time-stamps. }
-\item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+\item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 }}
 
 \item{fixed_effects}{A logic flag indicating whether to include unit fixed

--- a/man/GetWeights.Rd
+++ b/man/GetWeights.Rd
@@ -44,7 +44,7 @@ for smaller panels (less than 40 locations and 100 time-stamps.))}
 \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 to improve fit for larger panels (more than 40 locations and 100
 time-stamps. }
-\item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+\item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 }}
 
 \item{fixed_effects}{A logic flag indicating whether to include unit fixed

--- a/man/cumulative_lift.Rd
+++ b/man/cumulative_lift.Rd
@@ -55,7 +55,7 @@ for smaller panels (less than 40 locations and 100 time-stamps.))}
 \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 to improve fit for larger panels (more than 40 locations and 100
 time-stamps. }
-\item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+\item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 }}
 
 \item{fixed_effects}{A logic flag indicating whether to include unit fixed

--- a/man/cumulative_value.plot.Rd
+++ b/man/cumulative_value.plot.Rd
@@ -62,7 +62,7 @@ for smaller panels (less than 40 locations and 100 time-stamps.))}
 \item{"GSYN":}{ Augments with a Generalized Synthetic Control Method. Recommended
 to improve fit for larger panels (more than 40 locations and 100
 time-stamps. }
-\item{"best:}{ Fits the model with the lowest Scaled L2 Imbalance.}
+\item{"best":}{ Fits the model with the lowest Scaled L2 Imbalance.}
 }}
 
 \item{fixed_effects}{A logic flag indicating whether to include unit fixed

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(GeoLift)
+
+test_check("GeoLift")

--- a/tests/testthat/test_best_model.R
+++ b/tests/testthat/test_best_model.R
@@ -1,0 +1,141 @@
+context("model = 'best' consistency across entry points")
+
+## Shared synthetic panel: 8 locations x 60 periods, no treatment effect.
+make_panel <- function() {
+  set.seed(7)
+  units <- paste0("u", 1:8)
+  n_t <- 60
+  df <- expand.grid(location = units, time = 1:n_t, stringsAsFactors = FALSE)
+  df$Y <- 200 + 10 * sin(df$time / 5) +
+    as.numeric(factor(df$location)) * 15 + rnorm(nrow(df), 0, 3)
+  df
+}
+
+test_that("ResolveBestModel picks the lowest imbalance and excludes failures", {
+  # Fast unit tests of the selector itself, with ASCMExecution mocked out.
+  # l2s maps model name -> scaled_l2_imbalance value, or a function to error.
+  fake_ascm <- function(l2s) {
+    function(...) {
+      out <- l2s[[list(...)$model]]
+      if (is.function(out)) out()
+      list(augsynth_model = list(scaled_l2_imbalance = out))
+    }
+  }
+  resolve <- function(l2s) {
+    with_mocked_bindings(
+      suppressMessages(GeoLift:::ResolveBestModel(
+        data = data.frame(), treatment_locations = c("u1", "u2"),
+        treatment_start_time = 1, treatment_end_time = 2
+      )),
+      ASCMExecution = fake_ascm(l2s), .package = "GeoLift"
+    )
+  }
+  boom <- function() stop("fit failed")
+
+  # plain minimum
+  expect_equal(resolve(list(none = 0.8, ridge = 0.5, GSYN = 0.6)), "ridge")
+  expect_equal(resolve(list(none = 0.8, ridge = 0.6, GSYN = 0.5)), "GSYN")
+  # a failed candidate is never selected, even when the fitted ones tie
+  expect_equal(resolve(list(none = boom, ridge = 0.5, GSYN = 0.5)), "ridge")
+  # a strictly-worse 'none' is not selected on a ridge/GSYN tie
+  expect_equal(resolve(list(none = 0.8, ridge = 0.5, GSYN = 0.5)), "ridge")
+  # all-candidate tie goes to the simplest model
+  expect_equal(resolve(list(none = 0.5, ridge = 0.5, GSYN = 0.5)), "none")
+  # NaN / NULL imbalances are treated as failures, with a message
+  expect_message(
+    r <- with_mocked_bindings(
+      GeoLift:::ResolveBestModel(
+        data = data.frame(), treatment_locations = c("u1", "u2"),
+        treatment_start_time = 1, treatment_end_time = 2
+      ),
+      ASCMExecution = fake_ascm(list(none = NaN, ridge = 0.7, GSYN = NULL)),
+      .package = "GeoLift"
+    ),
+    "candidate 'none' failed"
+  )
+  expect_equal(r, "ridge")
+  # every candidate failing stops with a clear error
+  expect_error(resolve(list(none = boom, ridge = NaN, GSYN = boom)),
+               "every candidate model failed")
+  # single treatment location: GSYN skip must not make GSYN selectable
+  expect_equal(
+    with_mocked_bindings(
+      suppressMessages(GeoLift:::ResolveBestModel(
+        data = data.frame(), treatment_locations = "u1",
+        treatment_start_time = 1, treatment_end_time = 2
+      )),
+      ASCMExecution = fake_ascm(list(none = 0.8, ridge = 0.7)), .package = "GeoLift"
+    ),
+    "ridge"
+  )
+})
+
+test_that("simulation entry points reject model = 'best' with a clear error", {
+  df <- make_panel()
+  # Previously: "task 1 failed - \"progfunc must be one of ...\"" buried in a
+  # foreach worker; now an immediate, self-explanatory stop().
+  expect_error(
+    GeoLiftMarketSelection(
+      data = df, treatment_periods = 10, N = 1,
+      effect_size = c(-0.1), lookback_window = 1, cpic = 1,
+      model = "best"
+    ),
+    "only supported in GeoLift\\(\\) and GetWeights\\(\\)"
+  )
+  expect_error(
+    GeoLiftPower(
+      data = df, locations = c("u1"), effect_size = c(-0.1),
+      treatment_periods = 10, lookback_window = 1,
+      model = "best"
+    ),
+    "only supported in GeoLift\\(\\) and GetWeights\\(\\)"
+  )
+})
+
+test_that("GetWeights(model = 'best') works as documented", {
+  skip_on_cran()
+  skip_if_not_installed("augsynth")
+  df <- make_panel()
+  # Documented for years, previously died on augsynth's progfunc validation.
+  w <- suppressMessages(
+    GetWeights(
+      data = df, locations = c("u1", "u2"),
+      pretreatment_end_time = 50, model = "best"
+    )
+  )
+  expect_s3_class(w, "data.frame")
+  expect_true(all(c("location", "weight") %in% names(w)))
+  expect_gt(nrow(w), 0)
+  expect_true(all(is.finite(w$weight)))
+})
+
+test_that("GeoLift(model = 'best') announces the GSYN skip for a single location", {
+  skip_on_cran()
+  skip_if_not_installed("augsynth")
+  df <- make_panel()
+  expect_message(
+    g <- GeoLift(
+      Y_id = "Y", data = df, locations = "u1",
+      treatment_start_time = 51, treatment_end_time = 60,
+      model = "best"
+    ),
+    "skipping the GSYN candidate \\(single treatment location\\)"
+  )
+  expect_s3_class(g, "GeoLift")
+  expect_true(is.finite(g$inference$ATT))
+})
+
+test_that("GeoLift(model = 'ridge') is unaffected", {
+  skip_on_cran()
+  skip_if_not_installed("augsynth")
+  df <- make_panel()
+  g <- suppressMessages(
+    GeoLift(
+      Y_id = "Y", data = df, locations = "u1",
+      treatment_start_time = 51, treatment_end_time = 60,
+      model = "ridge"
+    )
+  )
+  expect_s3_class(g, "GeoLift")
+  expect_true(is.finite(g$inference$ATT))
+})


### PR DESCRIPTION
Addresses the mechanical parts of #231; the selection-criterion question raised there stays open.

`model = "best"` is only implemented inside `GeoLift()`. The other entry points pass the string straight into augsynth's `progfunc`: the simulation functions die with an unhelpful error inside a foreach worker, and `GetWeights()` documents `"best"` but errors the same way. Inside `GeoLift()`, a failed candidate is silently scored L2 = 1, which a real fit can lose to (scaled L2 can exceed 1).

- Extracted the "best" selection into an internal `ResolveBestModel()` helper that picks the lowest scaled L2 among the candidates that actually fitted, ties going to the simpler model. Failed candidates (error, or a non-finite imbalance) are excluded with a `message()`; if every candidate fails it stops. The previous comparison chain could return a failed candidate when the other two tied.
- `GetWeights(model = "best")` now works as documented, via the same helper.
- Added a clear early error for `model = "best"` in the five simulation entry points (it was never a documented value there).
- Removed `"best"` from the `ASCMExecution()` docs (never implemented there) and fixed the `\item{"best:}` typo; regenerated the affected man pages.
- Added a testthat scaffold: unit tests of the selector with `ASCMExecution` mocked, plus end-to-end checks (slow ones are `skip_on_cran()`).

Note: even with the GSYN fit repaired upstream (ebenmichael/augsynth#119), GSYN cannot currently win the comparison — for no-covariate runs augsynth reports the same scaled L2 for "none" and "GSYN" (details in #231). This PR only fixes the mechanics; what "best" should select on is #231 's open question.
